### PR TITLE
feat: taxonomy/terms improvements

### DIFF
--- a/blocks/build/dynamic-archive/render.php
+++ b/blocks/build/dynamic-archive/render.php
@@ -10,14 +10,13 @@
 use Timber\Timber;
 use Timber\FunctionWrapper;
 use Timber\URLHelper;
+use function Jcore\DynamicArchive\Helpers\build_dynamic_archive_block_base_args;
 use function Jcore\DynamicArchive\Helpers\build_pagination_url;
 use function Jcore\DynamicArchive\Helpers\build_param_name;
 use function Jcore\DynamicArchive\Helpers\build_taxonomies_filter;
 use function Jcore\DynamicArchive\Helpers\get_parameter;
 use function Jcore\DynamicArchive\Helpers\handle_dynamic_args;
-use function Jcore\DynamicArchive\Helpers\is_post_type;
 use function Jcore\DynamicArchive\Helpers\get_taxonomy_param_field_type;
-use function Jcore\DynamicArchive\Helpers\get_inherited_query_args;
 
 $context          = Timber::context();
 $context['block'] = $block;
@@ -29,86 +28,14 @@ if ( $parsed_url === false ) {
 }
 $context['current_path'] = $parsed_url;
 
-if ( ! is_post_type( $attributes['postType'] ?? '' ) ) {
-	$attributes['postType'] = 'post';
-}
-
 $context['block_wrapper_attributes'] = new FunctionWrapper( 'get_block_wrapper_attributes' );
-$context['taxonomies_filter']        = build_taxonomies_filter( $attributes );
+
+[ $attributes, $base_args ] = build_dynamic_archive_block_base_args( $attributes );
+$context['taxonomies_filter']        = build_taxonomies_filter( $attributes, $base_args );
 
 $block_per_page = $attributes['perPage'] ?? get_site_option( 'posts_per_page', 10 );
-$args           = array(
-	'post_type'      => $attributes['postType'],
-	'posts_per_page' => $block_per_page,
-	'post_status'    => 'publish',
-);
 
-// Only exclude the current post on singular pages to avoid showing the current post in related posts.
-// On archive pages, get_the_ID() returns the first post in the archive, which should not be excluded.
-if ( is_singular() ) {
-	$args['post__not_in'] = array( get_the_ID() );
-}
-
-// If inherit is true, we need to override the arguments with the current query.
-if ( $attributes['inherit'] ) {
-	$inherited = get_inherited_query_args();
-
-	// Merge post_type.
-	if ( ! empty( $inherited['post_type'] ) ) {
-		$args['post_type']      = $inherited['post_type'];
-		$attributes['postType'] = is_array( $inherited['post_type'] ) ? $inherited['post_type'][0] : $inherited['post_type'];
-	}
-
-	// Merge tax_query (will be layered upon by handle_dynamic_args / handle_taxonomies_filter).
-	if ( ! empty( $inherited['tax_query'] ) ) {
-		$args['tax_query'] = array_merge( $args['tax_query'] ?? array(), $inherited['tax_query'] );
-	}
-
-	// Merge author.
-	if ( ! empty( $inherited['author'] ) ) {
-		$args['author'] = $inherited['author'];
-	}
-
-	// Merge search only if the block's own search feature is disabled.
-	if ( ! ( $attributes['search'] ?? false ) && ! empty( $inherited['s'] ) ) {
-		$args['s'] = $inherited['s'];
-	}
-
-	// Merge date constraints.
-	foreach ( array( 'year', 'monthnum', 'day' ) as $date_key ) {
-		if ( ! empty( $inherited[ $date_key ] ) ) {
-			$args[ $date_key ] = $inherited[ $date_key ];
-		}
-	}
-
-	$selected_post_type     = get_post_type_object( $attributes['postType'] );
-	if ( ! $selected_post_type ) {
-		$selected_post_type = get_post_type_object( 'post' );
-	}
-	$attributes['postType'] = $selected_post_type->name;
-} else {
-	$selected_post_type = get_post_type_object( $attributes['postType'] );
-}
-
-
-if ( $selected_post_type->hierarchical && $attributes['hideChildren'] === true ) {
-	$args['post_parent'] = 0;
-}
-if ( isset( $attributes['sticky'] ) || ( $attributes['inherit'] && apply_filters( 'jcore_dynamic_archive_inherit_sticky', false ) ) ) {
-	$args_to_add = match ( $attributes['sticky'] ) {
-		'exclude' => array(
-			'post__not_in' => get_option( 'sticky_posts' ),
-		),
-		'only' => array(
-			'post__in'            => get_option( 'sticky_posts' ),
-			'ignore_sticky_posts' => true, // This might seem redundant, but all it does is improve performance. See https://wordpress.stackexchange.com/questions/260941/why-ignore-sticky-posts-argument-is-in-sticky-post-query#:~:text=Explanation%20of%20the%20codex%20example%3A for more information.
-		),
-		default => array(),
-	};
-	$args = array_merge( $args, $args_to_add );
-}
-
-$args = handle_dynamic_args( $args, $attributes );
+$args = handle_dynamic_args( $base_args, $attributes );
 /**
  * Filters the dynamic archive args for the dynamic archive block.
  *

--- a/blocks/src/dynamic-archive/render.php
+++ b/blocks/src/dynamic-archive/render.php
@@ -10,14 +10,13 @@
 use Timber\Timber;
 use Timber\FunctionWrapper;
 use Timber\URLHelper;
+use function Jcore\DynamicArchive\Helpers\build_dynamic_archive_block_base_args;
 use function Jcore\DynamicArchive\Helpers\build_pagination_url;
 use function Jcore\DynamicArchive\Helpers\build_param_name;
 use function Jcore\DynamicArchive\Helpers\build_taxonomies_filter;
 use function Jcore\DynamicArchive\Helpers\get_parameter;
 use function Jcore\DynamicArchive\Helpers\handle_dynamic_args;
-use function Jcore\DynamicArchive\Helpers\is_post_type;
 use function Jcore\DynamicArchive\Helpers\get_taxonomy_param_field_type;
-use function Jcore\DynamicArchive\Helpers\get_inherited_query_args;
 
 $context          = Timber::context();
 $context['block'] = $block;
@@ -29,86 +28,14 @@ if ( $parsed_url === false ) {
 }
 $context['current_path'] = $parsed_url;
 
-if ( ! is_post_type( $attributes['postType'] ?? '' ) ) {
-	$attributes['postType'] = 'post';
-}
-
 $context['block_wrapper_attributes'] = new FunctionWrapper( 'get_block_wrapper_attributes' );
-$context['taxonomies_filter']        = build_taxonomies_filter( $attributes );
+
+[ $attributes, $base_args ] = build_dynamic_archive_block_base_args( $attributes );
+$context['taxonomies_filter']        = build_taxonomies_filter( $attributes, $base_args );
 
 $block_per_page = $attributes['perPage'] ?? get_site_option( 'posts_per_page', 10 );
-$args           = array(
-	'post_type'      => $attributes['postType'],
-	'posts_per_page' => $block_per_page,
-	'post_status'    => 'publish',
-);
 
-// Only exclude the current post on singular pages to avoid showing the current post in related posts.
-// On archive pages, get_the_ID() returns the first post in the archive, which should not be excluded.
-if ( is_singular() ) {
-	$args['post__not_in'] = array( get_the_ID() );
-}
-
-// If inherit is true, we need to override the arguments with the current query.
-if ( $attributes['inherit'] ) {
-	$inherited = get_inherited_query_args();
-
-	// Merge post_type.
-	if ( ! empty( $inherited['post_type'] ) ) {
-		$args['post_type']      = $inherited['post_type'];
-		$attributes['postType'] = is_array( $inherited['post_type'] ) ? $inherited['post_type'][0] : $inherited['post_type'];
-	}
-
-	// Merge tax_query (will be layered upon by handle_dynamic_args / handle_taxonomies_filter).
-	if ( ! empty( $inherited['tax_query'] ) ) {
-		$args['tax_query'] = array_merge( $args['tax_query'] ?? array(), $inherited['tax_query'] );
-	}
-
-	// Merge author.
-	if ( ! empty( $inherited['author'] ) ) {
-		$args['author'] = $inherited['author'];
-	}
-
-	// Merge search only if the block's own search feature is disabled.
-	if ( ! ( $attributes['search'] ?? false ) && ! empty( $inherited['s'] ) ) {
-		$args['s'] = $inherited['s'];
-	}
-
-	// Merge date constraints.
-	foreach ( array( 'year', 'monthnum', 'day' ) as $date_key ) {
-		if ( ! empty( $inherited[ $date_key ] ) ) {
-			$args[ $date_key ] = $inherited[ $date_key ];
-		}
-	}
-
-	$selected_post_type     = get_post_type_object( $attributes['postType'] );
-	if ( ! $selected_post_type ) {
-		$selected_post_type = get_post_type_object( 'post' );
-	}
-	$attributes['postType'] = $selected_post_type->name;
-} else {
-	$selected_post_type = get_post_type_object( $attributes['postType'] );
-}
-
-
-if ( $selected_post_type->hierarchical && $attributes['hideChildren'] === true ) {
-	$args['post_parent'] = 0;
-}
-if ( isset( $attributes['sticky'] ) || ( $attributes['inherit'] && apply_filters( 'jcore_dynamic_archive_inherit_sticky', false ) ) ) {
-	$args_to_add = match ( $attributes['sticky'] ) {
-		'exclude' => array(
-			'post__not_in' => get_option( 'sticky_posts' ),
-		),
-		'only' => array(
-			'post__in'            => get_option( 'sticky_posts' ),
-			'ignore_sticky_posts' => true, // This might seem redundant, but all it does is improve performance. See https://wordpress.stackexchange.com/questions/260941/why-ignore-sticky-posts-argument-is-in-sticky-post-query#:~:text=Explanation%20of%20the%20codex%20example%3A for more information.
-		),
-		default => array(),
-	};
-	$args = array_merge( $args, $args_to_add );
-}
-
-$args = handle_dynamic_args( $args, $attributes );
+$args = handle_dynamic_args( $base_args, $attributes );
 /**
  * Filters the dynamic archive args for the dynamic archive block.
  *

--- a/blocks/templates/dynamic-archive/partials/filters.twig
+++ b/blocks/templates/dynamic-archive/partials/filters.twig
@@ -2,80 +2,89 @@
 	<div class="wp-block-jcore-dynamic-archive__filters__taxonomies">
 		{% for taxonomy in taxonomies_filter %}
 			{% if (taxonomy.forcedTerms|length) == 0 or (taxonomy.forcedTerms|length) > 1 %}
-				<div
-					class="wp-block-jcore-dynamic-archive__filters__taxonomies__type{{
-					' taxonomy-type-'
-						~ taxonomy.name
-					}}"
-				>
-					{% if taxonomy.label %}
-						<h3
-							class="wp-block-jcore-dynamic-archive__filters__taxonomies__type{{
-							' taxonomy-type-'
-								~ taxonomy.name
-							}}__label"
-							id="taxonomy-{{ attributes.instanceId }}-{{ taxonomy.name }}-label"
-						>
-							{{ taxonomy.label }}
-						</h3>
-					{% endif %}
-					{% if taxonomy.hierarchical %}
-						{# Parent categories #}
-						{% set parentTerms = taxonomy.terms|filter(term => term.isChild == false) %}
-						{% if (parentTerms|length) > 0 %}
-							<div
+				{% if taxonomy.hierarchical %}
+					{% set parentTerms = taxonomy.terms|filter(term => term.isChild == false) %}
+					{% set childTerms =
+						taxonomy.terms|filter(
+							term => term.isChild == true and term.parentActive == true
+						)
+					%}
+					{% set hasVisibleFilters = (parentTerms|length) > 0
+						or (childTerms|length) > 0
+					%}
+				{% else %}
+					{% set hasVisibleFilters = (taxonomy.terms|length) > 0 %}
+				{% endif %}
+				{% if hasVisibleFilters %}
+					<div
+						class="wp-block-jcore-dynamic-archive__filters__taxonomies__type{{
+						' taxonomy-type-'
+							~ taxonomy.name
+						}}"
+					>
+						{% if taxonomy.label %}
+							<h3
 								class="wp-block-jcore-dynamic-archive__filters__taxonomies__type{{
 								' taxonomy-type-'
 									~ taxonomy.name
-								}}__parents"
+								}}__label"
+								id="taxonomy-{{ attributes.instanceId }}-{{ taxonomy.name }}-label"
 							>
-								{% include [
-									'dynamic-archive/partials/filter-content.twig',
-									'partials/filter-content.twig'
-								] with {
-									taxonomy: taxonomy,
-									terms: parentTerms,
-									instanceId: attributes.instanceId,
-									isChild: false
-								} %}
-							</div>
+								{{ taxonomy.label }}
+							</h3>
 						{% endif %}
-						{# Child categories #}
-						{% set childTerms =
-							taxonomy.terms|filter(
-								term => term.isChild == true and term.parentActive == true
-							)
-						%}
-						{% if (childTerms|length) > 0 %}
-							<div
-								class="wp-block-jcore-dynamic-archive__filters__taxonomies__type{{
-								' taxonomy-type-'
-									~ taxonomy.name
-								}}__children"
-							>
-								{% include [
-									'dynamic-archive/partials/filter-content.twig',
-									'partials/filter-content.twig'
-								] with {
-									taxonomy: taxonomy,
-									terms: childTerms,
-									instanceId: attributes.instanceId,
-									isChild: true
-								} %}
-							</div>
+						{% if taxonomy.hierarchical %}
+							{# Parent categories #}
+							{% if (parentTerms|length) > 0 %}
+								<div
+									class="wp-block-jcore-dynamic-archive__filters__taxonomies__type{{
+									' taxonomy-type-'
+										~ taxonomy.name
+									}}__parents"
+								>
+									{% include [
+										'dynamic-archive/partials/filter-content.twig',
+										'partials/filter-content.twig'
+									] with {
+										taxonomy: taxonomy,
+										terms: parentTerms,
+										instanceId: attributes.instanceId,
+										isChild: false
+									} %}
+								</div>
+							{% endif %}
+							{# Child categories #}
+							{% if (childTerms|length) > 0 %}
+								<div
+									class="wp-block-jcore-dynamic-archive__filters__taxonomies__type{{
+									' taxonomy-type-'
+										~ taxonomy.name
+									}}__children"
+								>
+									{% include [
+										'dynamic-archive/partials/filter-content.twig',
+										'partials/filter-content.twig'
+									] with {
+										taxonomy: taxonomy,
+										terms: childTerms,
+										instanceId: attributes.instanceId,
+										isChild: true
+									} %}
+								</div>
+							{% endif %}
+						{% else %}
+							{% include [
+								'dynamic-archive/partials/filter-content.twig',
+								'partials/filter-content.twig'
+							] with {
+								taxonomy: taxonomy,
+								terms: taxonomy.terms,
+								instanceId: attributes.instanceId,
+								isChild: false
+							} %}
 						{% endif %}
-					{% else %}
-						{% include [
-							'dynamic-archive/partials/filter-content.twig',
-							'partials/filter-content.twig'
-						] with {
-							taxonomy: taxonomy,
-							terms: taxonomy.terms,
-							instanceId: attributes.instanceId,
-							isChild: false
-						} %}
-					{% endif %}
-				</div>
+					</div>
+				{% endif %}
 			{% endif %}
 		{% endfor %}
 	</div>

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -26,10 +26,11 @@ function is_post_type( string $post_type ): bool {
  *
  * @param array $args The arguments to handle.
  * @param array $attributes The attributes of the dynamic archive block.
+ * @param string|null $skip_taxonomy Optional taxonomy slug to omit from URL-driven tax_query.
  *
  * @return array
  */
-function handle_dynamic_args( array $args, array $attributes ): array {
+function handle_dynamic_args( array $args, array $attributes, ?string $skip_taxonomy = null ): array {
 	$instance_id = $attributes['instanceId'] ?? '';
 	if ( ( $attributes['showPagination'] ?? false ) && ! ( $attributes['infiniteScroll'] ?? false ) ) {
 		$args['paged'] = get_parameter( build_param_name( 'archive-paged', $instance_id, $attributes ), 1, );
@@ -58,7 +59,7 @@ function handle_dynamic_args( array $args, array $attributes ): array {
 		}
 	}
 
-	return handle_taxonomies_filter( $args, $attributes );
+	return handle_taxonomies_filter( $args, $attributes, $skip_taxonomy );
 }
 
 /**
@@ -66,16 +67,20 @@ function handle_dynamic_args( array $args, array $attributes ): array {
  *
  * @param array $args The arguments to handle.
  * @param array $attributes The attributes of the dynamic archive block.
+ * @param string|null $skip_taxonomy Optional taxonomy slug to omit from URL-driven tax_query.
  *
  * @return array
  */
-function handle_taxonomies_filter( array $args, array $attributes ): array {
+function handle_taxonomies_filter( array $args, array $attributes, ?string $skip_taxonomy = null ): array {
 	$instance_id = $attributes['instanceId'] ?? '';
 	$all_filters = get_parameter( build_param_name( 'taxonomy', $instance_id, $attributes ), array() );
 
 	[$taxonomy_filters] = extract_taxonomy_filter_attributes( $attributes );
 
 	foreach ( $taxonomy_filters ?? array() as $taxonomy ) {
+		if ( null !== $skip_taxonomy && $taxonomy === $skip_taxonomy ) {
+			continue;
+		}
 		$active_filters = get_nested_value( $all_filters, array( $taxonomy ), array() );
 		if ( empty( $active_filters ) ) {
 			continue;
@@ -159,6 +164,184 @@ function handle_taxonomies_filter( array $args, array $attributes ): array {
 	 * @hooked jcore_dynamic_archive_tax_query
 	 */
 	return apply_filters( 'jcore_dynamic_archive_tax_query', $args, $attributes, $all_filters );
+}
+
+/**
+ * Builds base WP_Query args for the dynamic archive block (before handle_dynamic_args).
+ *
+ * Mirrors {@see blocks/src/dynamic-archive/render.php}: defaults, singular exclusion, inherit merge,
+ * hierarchical post_parent, sticky handling.
+ *
+ * @param array $attributes Block attributes (postType normalized; may be updated when inherit is true).
+ *
+ * @return array{0: array, 1: array} [ $attributes, $args ]
+ */
+function build_dynamic_archive_block_base_args( array $attributes ): array {
+	if ( ! is_post_type( $attributes['postType'] ?? '' ) ) {
+		$attributes['postType'] = 'post';
+	}
+
+	$block_per_page = $attributes['perPage'] ?? get_site_option( 'posts_per_page', 10 );
+	$args           = array(
+		'post_type'      => $attributes['postType'],
+		'posts_per_page' => $block_per_page,
+		'post_status'    => 'publish',
+	);
+
+	if ( is_singular() ) {
+		$args['post__not_in'] = array( get_the_ID() );
+	}
+
+	if ( ! empty( $attributes['inherit'] ) ) {
+		$inherited = get_inherited_query_args();
+
+		if ( ! empty( $inherited['post_type'] ) ) {
+			$args['post_type']      = $inherited['post_type'];
+			$attributes['postType'] = is_array( $inherited['post_type'] ) ? $inherited['post_type'][0] : $inherited['post_type'];
+		}
+
+		if ( ! empty( $inherited['tax_query'] ) ) {
+			$args['tax_query'] = array_merge( $args['tax_query'] ?? array(), $inherited['tax_query'] );
+		}
+
+		if ( ! empty( $inherited['author'] ) ) {
+			$args['author'] = $inherited['author'];
+		}
+
+		if ( ! ( $attributes['search'] ?? false ) && ! empty( $inherited['s'] ) ) {
+			$args['s'] = $inherited['s'];
+		}
+
+		foreach ( array( 'year', 'monthnum', 'day' ) as $date_key ) {
+			if ( ! empty( $inherited[ $date_key ] ) ) {
+				$args[ $date_key ] = $inherited[ $date_key ];
+			}
+		}
+
+		$selected_post_type = get_post_type_object( $attributes['postType'] );
+		if ( ! $selected_post_type ) {
+			$selected_post_type = get_post_type_object( 'post' );
+		}
+		$attributes['postType'] = $selected_post_type->name;
+	} else {
+		$selected_post_type = get_post_type_object( $attributes['postType'] );
+		if ( ! $selected_post_type ) {
+			$selected_post_type = get_post_type_object( 'post' );
+		}
+	}
+
+	if ( $selected_post_type->hierarchical && ( $attributes['hideChildren'] ?? false ) === true ) {
+		$args['post_parent'] = 0;
+	}
+
+	if ( isset( $attributes['sticky'] ) || ( ! empty( $attributes['inherit'] ) && apply_filters( 'jcore_dynamic_archive_inherit_sticky', false ) ) ) {
+		$args_to_add = match ( $attributes['sticky'] ?? 'include' ) {
+			'exclude' => array(
+				'post__not_in' => get_option( 'sticky_posts' ),
+			),
+			'only' => array(
+				'post__in'            => get_option( 'sticky_posts' ),
+				'ignore_sticky_posts' => true,
+			),
+			default => array(),
+		};
+		$args = array_merge( $args, $args_to_add );
+	}
+
+	return array( $attributes, $args );
+}
+
+/**
+ * Strips pagination and limits for enumerating all matching post IDs (faceted term discovery).
+ *
+ * @param array $args WP_Query arguments.
+ *
+ * @return array
+ */
+function normalize_dynamic_archive_query_args_for_facet( array $args ): array {
+	unset( $args['paged'] );
+	$args['posts_per_page']         = -1;
+	$args['fields']                 = 'ids';
+	$args['no_found_rows']          = true;
+	$args['update_post_meta_cache'] = false;
+	$args['update_post_term_cache'] = false;
+	return $args;
+}
+
+/**
+ * Returns term IDs that appear on at least one post matching the current query, excluding URL filters for $taxonomy.
+ *
+ * @param string $taxonomy   Taxonomy slug.
+ * @param array  $attributes Block attributes (same merge as main query).
+ *
+ * @return int[] Distinct term IDs.
+ */
+function get_applicable_term_ids_for_taxonomy( string $taxonomy, array $attributes ): array {
+	[ $merged_attributes, $base_args ] = build_dynamic_archive_block_base_args( $attributes );
+	$facet_args                        = handle_dynamic_args( $base_args, $merged_attributes, $taxonomy );
+	$facet_args                        = apply_filters( 'jcore_dynamic_archive_args', $facet_args, $merged_attributes );
+	$facet_args                        = normalize_dynamic_archive_query_args_for_facet( $facet_args );
+	/**
+	 * Filters WP_Query args used to discover applicable terms for a taxonomy (faceted filters).
+	 *
+	 * @param array  $facet_args        Query args (post IDs enumeration).
+	 * @param string $taxonomy          Taxonomy being faceted.
+	 * @param array  $merged_attributes Block attributes after inherit merge.
+	 */
+	$facet_args = apply_filters( 'jcore_dynamic_archive_facet_term_query_args', $facet_args, $taxonomy, $merged_attributes );
+
+	$query = new \WP_Query( $facet_args );
+	if ( empty( $query->posts ) || ! is_array( $query->posts ) ) {
+		return array();
+	}
+
+	$term_ids = wp_get_object_terms(
+		$query->posts,
+		$taxonomy,
+		array(
+			'fields'                 => 'ids',
+			'update_term_meta_cache' => false,
+		)
+	);
+
+	if ( is_wp_error( $term_ids ) || ! is_array( $term_ids ) ) {
+		return array();
+	}
+
+	$term_ids = array_values( array_unique( array_map( 'absint', $term_ids ) ) );
+
+	$tax_object = get_taxonomy( $taxonomy );
+	if ( $tax_object && $tax_object->hierarchical && ! empty( $term_ids ) ) {
+		$ancestors = array();
+		foreach ( $term_ids as $tid ) {
+			$chain = get_ancestors( $tid, $taxonomy, 'taxonomy' );
+			if ( is_array( $chain ) ) {
+				foreach ( $chain as $ancestor_id ) {
+					$ancestors[] = absint( $ancestor_id );
+				}
+			}
+		}
+		if ( ! empty( $ancestors ) ) {
+			$term_ids = array_values( array_unique( array_merge( $term_ids, $ancestors ) ) );
+		}
+	}
+
+	return $term_ids;
+}
+
+/**
+ * Builds full WP_Query args for the dynamic archive block (same as main Timber query).
+ *
+ * @param array       $attributes Block attributes.
+ * @param string|null $skip_taxonomy Optional taxonomy slug to omit from URL-driven tax_query (faceting).
+ *
+ * @return array{0: array, 1: array} [ $attributes, $args ]
+ */
+function build_dynamic_archive_query_args( array $attributes, ?string $skip_taxonomy = null ): array {
+	[ $attributes, $base_args ] = build_dynamic_archive_block_base_args( $attributes );
+	$args                       = handle_dynamic_args( $base_args, $attributes, $skip_taxonomy );
+	$args                       = apply_filters( 'jcore_dynamic_archive_args', $args, $attributes );
+	return array( $attributes, $args );
 }
 
 /**
@@ -328,11 +511,16 @@ function extract_taxonomy_filter_attributes( array $attributes ): array {
 /**
  * Handles constructing the taxonomies filter for the dynamic archive block.
  *
- * @param array $attributes The attributes of the dynamic archive block.
+ * @param array      $attributes The attributes of the dynamic archive block (after inherit merge when passed from render).
+ * @param array|null $base_args  Optional base query args from {@see build_dynamic_archive_block_base_args()} to avoid duplicate work.
  *
  * @return array
  */
-function build_taxonomies_filter( array $attributes ): array {
+function build_taxonomies_filter( array $attributes, ?array $base_args = null ): array {
+	if ( null === $base_args ) {
+		[ $attributes, $base_args ] = build_dynamic_archive_block_base_args( $attributes );
+	}
+
 	// Extract the taxonomy filters, filter types, filter types child, and hierarchical filter from the attributes.
 	[$taxonomy_filters, $filter_types, $filter_types_child, $hierarchical_filter] = extract_taxonomy_filter_attributes( $attributes );
 
@@ -340,6 +528,7 @@ function build_taxonomies_filter( array $attributes ): array {
 	$instance_id        = $attributes['instanceId'] ?? '';
 	$all_filters        = get_parameter( build_param_name( 'taxonomy', $instance_id, $attributes ), array() );
 	$selected_post_type = get_taxonomies_filter_post_type( $attributes );
+	$query_aware        = apply_filters( 'jcore_dynamic_archive_taxonomies_filter_query_aware', false, $attributes, $all_filters );
 
 	foreach ( $taxonomy_filters as $taxonomy ) {
 		// Get taxonomy object.
@@ -371,6 +560,15 @@ function build_taxonomies_filter( array $attributes ): array {
 		}
 		$active_filters = array_map( 'absint', $active_filters );
 
+		$applicable_map = array();
+		if ( $query_aware ) {
+			$applicable_ids = get_applicable_term_ids_for_taxonomy( $taxonomy, $attributes );
+			$applicable_map = array_fill_keys( $applicable_ids, true );
+			foreach ( $active_filters as $aid ) {
+				$applicable_map[ absint( $aid ) ] = true;
+			}
+		}
+
 		$terms                   = get_terms(
 			array(
 				'taxonomy'   => $taxonomy,
@@ -398,6 +596,9 @@ function build_taxonomies_filter( array $attributes ): array {
 			if ( $has_forced && ! in_array( $term->term_id, $forced_terms, true ) ) {
 				continue;
 			}
+			if ( $query_aware && ! isset( $applicable_map[ $term->term_id ] ) ) {
+				continue;
+			}
 			$taxonomies[ $taxonomy ]['terms'][] = array(
 				'id'           => $term->term_id,
 				'type'         => $term->taxonomy,
@@ -409,6 +610,9 @@ function build_taxonomies_filter( array $attributes ): array {
 				'filterType'   => $filter_type,
 				'active'       => in_array( $term->term_id, $active_filters, true ),
 			);
+		}
+		if ( $query_aware && empty( $taxonomies[ $taxonomy ]['terms'] ) ) {
+			unset( $taxonomies[ $taxonomy ] );
 		}
 	}
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -404,6 +404,23 @@ function build_taxonomies_filter( array $attributes ): array {
 			);
 		}
 	}
+
+	$sort_terms_by_name = apply_filters( 'jcore_dynamic_archive_sort_taxonomy_terms_by_name', true, $attributes, $all_filters );
+	if ( $sort_terms_by_name ) {
+		foreach ( $taxonomies as &$taxonomy_data ) {
+			if ( empty( $taxonomy_data['terms'] ) || ! is_array( $taxonomy_data['terms'] ) ) {
+				continue;
+			}
+			usort(
+				$taxonomy_data['terms'],
+				static function ( array $a, array $b ): int {
+					return strcasecmp( $a['name'] ?? '', $b['name'] ?? '' );
+				}
+			);
+		}
+		unset( $taxonomy_data );
+	}
+
 	/**
 	 * Filters the taxonomies filter for the dynamic archive block.
 	 *
@@ -412,6 +429,8 @@ function build_taxonomies_filter( array $attributes ): array {
 	 * @param array $all_filters All currently active filters.
 	 *
 	 * @hooked jcore_dynamic_archive_taxonomies_filter
+	 *
+	 * Terms are sorted by name (case-insensitive) when {@see 'jcore_dynamic_archive_sort_taxonomy_terms_by_name'} returns true.
 	 */
 	return apply_filters( 'jcore_dynamic_archive_taxonomies_filter', $taxonomies, $attributes, $all_filters );
 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -336,14 +336,18 @@ function build_taxonomies_filter( array $attributes ): array {
 	// Extract the taxonomy filters, filter types, filter types child, and hierarchical filter from the attributes.
 	[$taxonomy_filters, $filter_types, $filter_types_child, $hierarchical_filter] = extract_taxonomy_filter_attributes( $attributes );
 
-	$taxonomies  = array();
-	$instance_id = $attributes['instanceId'] ?? '';
-	$all_filters = get_parameter( build_param_name( 'taxonomy', $instance_id, $attributes ), array() );
+	$taxonomies         = array();
+	$instance_id        = $attributes['instanceId'] ?? '';
+	$all_filters        = get_parameter( build_param_name( 'taxonomy', $instance_id, $attributes ), array() );
+	$selected_post_type = get_taxonomies_filter_post_type( $attributes );
 
 	foreach ( $taxonomy_filters as $taxonomy ) {
 		// Get taxonomy object.
-		$tax_object   = get_taxonomy( $taxonomy );
-		$forced_terms = get_nested_value( $attributes, array( 'forcedCategories', $taxonomy ), array() );
+		$tax_object                  = get_taxonomy( $taxonomy );
+		$forced_terms                = get_nested_value( $attributes, array( 'forcedCategories', $taxonomy ), array() );
+		$use_post_type_term_usage    = ! $attributes['showAllLanguages'] && '' !== $selected_post_type && apply_filters( 'jcore_dynamic_archive_use_post_type_term_usage', false, $taxonomy, $selected_post_type, $attributes, $all_filters );
+		$post_type_used_term_ids     = $use_post_type_term_usage ? get_term_ids_in_use_for_post_type( $taxonomy, $selected_post_type ) : array();
+		$post_type_used_term_ids_map = $use_post_type_term_usage ? array_fill_keys( $post_type_used_term_ids, true ) : array();
 		if ( ! is_array( $forced_terms ) || $attributes['inherit'] ) {
 			$forced_terms = array();
 		}
@@ -370,7 +374,7 @@ function build_taxonomies_filter( array $attributes ): array {
 		$terms                   = get_terms(
 			array(
 				'taxonomy'   => $taxonomy,
-				'hide_empty' => ! $attributes['showAllLanguages'], // Show empty if all languages are shown.
+				'hide_empty' => ! $attributes['showAllLanguages'] && ! $use_post_type_term_usage, // Show empty if all languages are shown or term usage is filtered by post type.
 			)
 		);
 		$taxonomies[ $taxonomy ] = array(
@@ -386,6 +390,9 @@ function build_taxonomies_filter( array $attributes ): array {
 			$filter_type = $taxonomies[ $taxonomy ]['filterType'] ?? 'checkbox';
 			if ( ( $taxonomies[ $taxonomy ]['hierarchical'] ?? false ) && $term->parent > 0 ) {
 				$filter_type = $taxonomies[ $taxonomy ]['filterTypeChild'] ?? 'checkbox';
+			}
+			if ( $use_post_type_term_usage && ! isset( $post_type_used_term_ids_map[ $term->term_id ] ) ) {
+				continue;
 			}
 			// Handles only showing forced categories.
 			if ( $has_forced && ! in_array( $term->term_id, $forced_terms, true ) ) {
@@ -433,6 +440,32 @@ function build_taxonomies_filter( array $attributes ): array {
 	 * Terms are sorted by name (case-insensitive) when {@see 'jcore_dynamic_archive_sort_taxonomy_terms_by_name'} returns true.
 	 */
 	return apply_filters( 'jcore_dynamic_archive_taxonomies_filter', $taxonomies, $attributes, $all_filters );
+}
+
+/**
+ * Resolves the post type used for the taxonomy filter.
+ *
+ * @param array $attributes The attributes of the dynamic archive block.
+ *
+ * @return string
+ */
+function get_taxonomies_filter_post_type( array $attributes ): string {
+	$post_type = $attributes['postType'] ?? '';
+	if ( ! is_string( $post_type ) || ! is_post_type( $post_type ) ) {
+		$post_type = 'post';
+	}
+
+	if ( ! empty( $attributes['inherit'] ) ) {
+		$inherited_post_type = get_nested_value( get_inherited_query_args(), array( 'post_type' ), '' );
+		if ( is_array( $inherited_post_type ) ) {
+			$inherited_post_type = reset( $inherited_post_type ) ?: '';
+		}
+		if ( is_string( $inherited_post_type ) && is_post_type( $inherited_post_type ) ) {
+			$post_type = $inherited_post_type;
+		}
+	}
+
+	return $post_type;
 }
 
 /**

--- a/includes/term-post-type-usage.php
+++ b/includes/term-post-type-usage.php
@@ -1,0 +1,267 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Jcore\DynamicArchive\Helpers;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+const TERM_POST_TYPE_USAGE_CACHE_GROUP = 'jcore_dynamic_archive_term_pt';
+const TERM_POST_TYPE_USAGE_VERSION_OPTION = 'jcore_dynamic_archive_term_pt_usage_version';
+
+/**
+ * Stores a value in the cache.
+ *
+ * @param string $key The cache key.
+ * @param mixed $value The value to store.
+ * @param int $ttl The cache TTL.
+ *
+ * @return void
+ */
+function store_value( string $key, mixed $value, int $ttl ): void {
+	if ( ! wp_using_ext_object_cache() ) {
+		set_transient( $key, $value, $ttl );
+	} else {
+		wp_cache_set( $key, $value, TERM_POST_TYPE_USAGE_CACHE_GROUP, $ttl );
+	}
+}
+
+/**
+ * Gets a value from the cache.
+ *
+ * @param string $key The cache key.
+ *
+ * @return mixed
+ */
+function get_value( string $key ): mixed {
+	if ( ! wp_using_ext_object_cache() ) {
+		return get_transient( $key );
+	} else {
+		return wp_cache_get( $key, TERM_POST_TYPE_USAGE_CACHE_GROUP );
+	}
+}
+
+/**
+ * Gets the cache key version for term usage by post type.
+ *
+ * @return int
+ */
+function get_term_post_type_usage_cache_version(): int {
+	$version = absint( get_option( TERM_POST_TYPE_USAGE_VERSION_OPTION, 1 ) );
+	if ( $version < 1 ) {
+		$version = 1;
+		update_option( TERM_POST_TYPE_USAGE_VERSION_OPTION, $version, false );
+	}
+
+	return $version;
+}
+
+/**
+ * Builds a cache key for term usage by post type.
+ *
+ * @param string $taxonomy The taxonomy name.
+ * @param string $post_type The post type name.
+ *
+ * @return string
+ */
+function get_term_post_type_usage_cache_key( string $taxonomy, string $post_type ): string {
+	$version = get_term_post_type_usage_cache_version();
+	return 'jcore_tpu_' . md5( $version . '|' . $taxonomy . '|' . $post_type );
+}
+
+/**
+ * Gets the cache ttl for term usage by post type.
+ *
+ * @param string $taxonomy The taxonomy name.
+ * @param string $post_type The post type name.
+ *
+ * @return int
+ */
+function get_term_post_type_usage_cache_ttl( string $taxonomy, string $post_type ): int {
+	$ttl = (int) apply_filters(
+		'jcore_dynamic_archive_term_post_type_usage_cache_ttl',
+		DAY_IN_SECONDS,
+		$taxonomy,
+		$post_type
+	);
+
+	return $ttl > 0 ? $ttl : DAY_IN_SECONDS;
+}
+
+/**
+ * Returns term IDs used by a specific post type within a taxonomy.
+ *
+ * @param string $taxonomy The taxonomy name.
+ * @param string $post_type The post type name.
+ *
+ * @return int[]
+ */
+function get_term_ids_in_use_for_post_type( string $taxonomy, string $post_type ): array {
+	global $wpdb;
+
+	if ( ! taxonomy_exists( $taxonomy ) || ! post_type_exists( $post_type ) ) {
+		return array();
+	}
+
+	$cache_key = get_term_post_type_usage_cache_key( $taxonomy, $post_type );
+	$cached    = get_value( $cache_key );
+	if ( is_array( $cached ) ) {
+		return array_values( array_map( 'absint', $cached ) );
+	}
+
+	$post_statuses = array_keys( get_post_stati( array( 'public' => true ) ) );
+	$post_statuses = apply_filters(
+		'jcore_dynamic_archive_term_post_type_usage_post_statuses',
+		$post_statuses,
+		$taxonomy,
+		$post_type
+	);
+	if ( ! is_array( $post_statuses ) || empty( $post_statuses ) ) {
+		$post_statuses = array( 'publish' );
+	}
+	$post_statuses = array_values( array_filter( array_map( 'sanitize_key', $post_statuses ) ) );
+	if ( empty( $post_statuses ) ) {
+		$post_statuses = array( 'publish' );
+	}
+
+	$placeholders = implode( ', ', array_fill( 0, count( $post_statuses ), '%s' ) );
+	$query        = "
+		SELECT DISTINCT tt.term_id
+		FROM {$wpdb->term_relationships} tr
+		INNER JOIN {$wpdb->term_taxonomy} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id
+		INNER JOIN {$wpdb->posts} p ON p.ID = tr.object_id
+		WHERE tt.taxonomy = %s
+		AND p.post_type = %s
+		AND p.post_status IN ($placeholders)
+	";
+	$args         = array_merge( array( $taxonomy, $post_type ), $post_statuses );
+	$prepared     = $wpdb->prepare( $query, $args );
+	$term_ids     = $prepared ? $wpdb->get_col( $prepared ) : array(); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+	$term_ids     = array_values( array_unique( array_map( 'absint', $term_ids ) ) );
+
+	$ttl = get_term_post_type_usage_cache_ttl( $taxonomy, $post_type );
+	store_value( $cache_key, $term_ids, $ttl );
+
+	return $term_ids;
+}
+
+/**
+ * Checks whether a term is in use for a specific post type.
+ *
+ * @param int    $term_id The term ID.
+ * @param string $taxonomy The taxonomy name.
+ * @param string $post_type The post type name.
+ *
+ * @return bool
+ */
+function term_is_in_use_for_post_type( int $term_id, string $taxonomy, string $post_type ): bool {
+	return in_array( absint( $term_id ), get_term_ids_in_use_for_post_type( $taxonomy, $post_type ), true );
+}
+
+/**
+ * Invalidates term usage cache for a taxonomy and post type pair.
+ *
+ * If taxonomy and post type are omitted, all keys are invalidated by bumping
+ * the internal cache version.
+ *
+ * @param string|null $taxonomy The taxonomy name.
+ * @param string|null $post_type The post type name.
+ *
+ * @return void
+ */
+function invalidate_term_post_type_usage_cache( ?string $taxonomy = null, ?string $post_type = null ): void {
+	if ( null === $taxonomy && null === $post_type ) {
+		update_option( TERM_POST_TYPE_USAGE_VERSION_OPTION, get_term_post_type_usage_cache_version() + 1, false );
+		return;
+	}
+
+	if ( empty( $taxonomy ) || empty( $post_type ) ) {
+		return;
+	}
+
+	$cache_key = get_term_post_type_usage_cache_key( $taxonomy, $post_type );
+	delete_transient( $cache_key );
+	wp_cache_delete( $cache_key, TERM_POST_TYPE_USAGE_CACHE_GROUP );
+}
+
+/**
+ * Invalidates cache for all taxonomies attached to a post type.
+ *
+ * @param string $post_type The post type name.
+ *
+ * @return void
+ */
+function invalidate_term_post_type_usage_cache_for_post_type( string $post_type ): void {
+	if ( ! post_type_exists( $post_type ) ) {
+		return;
+	}
+
+	$taxonomies = get_object_taxonomies( $post_type, 'names' );
+	foreach ( $taxonomies as $taxonomy ) {
+		invalidate_term_post_type_usage_cache( $taxonomy, $post_type );
+	}
+}
+
+/**
+ * Handles cache invalidation on post save.
+ *
+ * @param int           $post_id The post ID.
+ * @param \WP_Post|null $post The post object.
+ * @param bool     $update Whether this is an existing post being updated.
+ *
+ * @return void
+ */
+function handle_term_post_type_usage_save_post( int $post_id, \WP_Post $post, bool $update ): void {
+	unset( $update );
+
+	if ( wp_is_post_autosave( $post_id ) || wp_is_post_revision( $post_id ) ) {
+		return;
+	}
+
+	invalidate_term_post_type_usage_cache_for_post_type( $post->post_type );
+}
+
+/**
+ * Handles cache invalidation on post deletion.
+ *
+ * @param int      $post_id The post ID.
+ * @param \WP_Post $post The post object.
+ *
+ * @return void
+ */
+function handle_term_post_type_usage_deleted_post( int $post_id, ?\WP_Post $post = null ): void {
+	$post_type = $post instanceof \WP_Post ? $post->post_type : get_post_type( $post_id );
+	if ( ! is_string( $post_type ) || '' === $post_type ) {
+		return;
+	}
+
+	invalidate_term_post_type_usage_cache_for_post_type( $post_type );
+}
+
+/**
+ * Handles cache invalidation on term assignment changes.
+ *
+ * @param int          $object_id The object ID.
+ * @param int[]|string $terms The terms.
+ * @param int[]        $tt_ids The term taxonomy IDs.
+ * @param string       $taxonomy The taxonomy.
+ * @param bool         $append Whether to append terms.
+ * @param int[]        $old_tt_ids Old term taxonomy IDs.
+ *
+ * @return void
+ */
+function handle_term_post_type_usage_set_object_terms( int $object_id, $terms, array $tt_ids, string $taxonomy, bool $append, array $old_tt_ids ): void {
+	unset( $terms, $tt_ids, $append, $old_tt_ids );
+
+	$post_type = get_post_type( $object_id );
+	if ( ! is_string( $post_type ) || '' === $post_type ) {
+		return;
+	}
+
+	invalidate_term_post_type_usage_cache( $taxonomy, $post_type );
+}
+
+add_action( 'save_post', __NAMESPACE__ . '\\handle_term_post_type_usage_save_post', 10, 3 );
+add_action( 'deleted_post', __NAMESPACE__ . '\\handle_term_post_type_usage_deleted_post', 10, 2 );
+add_action( 'before_delete_post', __NAMESPACE__ . '\\handle_term_post_type_usage_deleted_post', 10, 2 );
+add_action( 'set_object_terms', __NAMESPACE__ . '\\handle_term_post_type_usage_set_object_terms', 10, 6 );

--- a/jcore-dynamic-archive.php
+++ b/jcore-dynamic-archive.php
@@ -20,6 +20,7 @@ if ( is_file( __DIR__ . '/vendor/autoload.php' ) ) {
 
 require_once __DIR__ . '/consts.php';
 require_once __DIR__ . '/includes/helpers.php';
+require_once __DIR__ . '/includes/term-post-type-usage.php';
 require_once __DIR__ . '/blocks/dynamic-archive.php';
 
 DynamicArchive\Bootstrap::init();


### PR DESCRIPTION
In this PR, terms/taxonomy filtering gets an upgrade:
- Terms which are shared between post types are now not shown when empty for the currently queried post type
- When filtering on the frontend, other "impossible" filter combos are hidden

To preserve backward compatibility it is gated behind filters:
## Query aware filters:
`add_filter( 'jcore_dynamic_archive_taxonomies_filter_query_aware', '__return_true);`

## Hide empty for shared terms:
`add_filter( 'jcore_dynamic_archive_use_post_type_term_usage', '__return_true' );`